### PR TITLE
fixed attachment detection for rare case with multiline utf8 headers

### DIFF
--- a/src/Fetch/Attachment.php
+++ b/src/Fetch/Attachment.php
@@ -116,6 +116,16 @@ class Attachment
 
         $parameters = Message::getParametersFromStructure($structure);
 
+        // quick fix for Content-Disposition extended notation
+        // name*0*=UTF-8''%D0%A...
+        // name*1*=%D0%B8...
+        // etc
+        if (!empty($parameters['filename*'])) {
+            $this->setFileName($parameters['filename*']);
+        } elseif (!empty($parameters['name*'])) {
+            $this->setFileName($parameters['name*']);
+        }
+
         if (!empty($parameters['filename'])) {
             $this->setFileName($parameters['filename']);
         } elseif (!empty($parameters['name'])) {

--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -534,6 +534,17 @@ class Message
     {
         $parameters = self::getParametersFromStructure($structure);
 
+        // quick fix for Content-Disposition extended notation
+        // name*0*=UTF-8''%D0%A...
+        // name*1*=%D0%B8...
+        // etc
+        if (empty($parameters['name']) && !empty($parameters['name*'])) {
+            $parameters['name'] = $parameters['name*'];
+        }
+        if (empty($parameters['filename']) && !empty($parameters['filename*'])) {
+            $parameters['filename'] = $parameters['filename*'];
+        }
+
         if (!empty($parameters['name']) || !empty($parameters['filename'])) {
             $attachment = new Attachment($this, $structure, $partIdentifier);
             $this->attachments[] = $attachment;


### PR DESCRIPTION
some mail servers may form multiline or utf8 letter headers in a different way, still rfc-compliant, by using asterisk as a line separator. the example of such header is the following:
```
Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document;
 name*0*=UTF-8''%D0%A1%D0%...
 name*1*=%D0%B8%D0%B7%D0%...
 name*2*=%20%281%29.docx
```
while majority of servers use different notation:
```
Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document;
 name="=?UTF-8?Q?=D0=A1=D0...
 =?UTF-8?Q?=D0=B8=D0=B7=D0...
 =?UTF-8?Q?=281=29_=281=29=2Edocx?="
 ```
the latter is supported by Fetch, while former fails to be parsed, so attachment is such letter cannot be found by Fetch
proposed fix may improve attachment detection in that case