### PR TITLE
fixed oversight of multiline utf8 headers being urlencoded

### DIFF
--- a/src/Fetch/Attachment.php
+++ b/src/Fetch/Attachment.php
@@ -121,9 +121,9 @@ class Attachment
         // name*1*=%D0%B8...
         // etc
         if (!empty($parameters['filename*'])) {
-            $this->setFileName($parameters['filename*']);
+            $this->setFileName(urldecode($parameters['filename*']));
         } elseif (!empty($parameters['name*'])) {
-            $this->setFileName($parameters['name*']);
+            $this->setFileName(urldecode($parameters['name*']));
         }
 
         if (!empty($parameters['filename'])) {


### PR DESCRIPTION
the previous PR was flawed, as the attachment name would retain url encoding from header. I've added urldecode to keep filenames human readable